### PR TITLE
add better getTitle method for Category.

### DIFF
--- a/src/main/java/com/agiletec/aps/system/services/category/Category.java
+++ b/src/main/java/com/agiletec/aps/system/services/category/Category.java
@@ -73,7 +73,7 @@ public class Category extends TreeNode implements Comparable {
 	 */
 	public String getTitle() {
 		String title = null;
-		if (this._renderingLang != null) {
+		if (this._renderingLang != null && null != this.getTitles().get(this._renderingLang)) {
 			title = (String) this.getTitles().get(this._renderingLang);
 		} else {
 			title = (String) this.getTitles().get(this._defaultLang);
@@ -83,6 +83,7 @@ public class Category extends TreeNode implements Comparable {
 		}
 		return title;
 	}
+	
 	
 	/**
 	 * Restituisce il titolo (comprensivo delle progenitrici) della 


### PR DESCRIPTION
Hi there,

In category.getTitle(), when the renderingLang is not null, and the title for that lang is null, the returned value was null. With this patch now takes the defaultLang value.

Hope helps!

Regards,
Stefano
