### PR TITLE
add "page resolution by widget" for PageInfoTag

### DIFF
--- a/src/main/tld/aps-core.tld
+++ b/src/main/tld/aps-core.tld
@@ -404,7 +404,13 @@
 		<attribute>
 			<description><![CDATA[The code of the page.]]></description>
 			<name>pageCode</name>
-			<required>true</required>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description><![CDATA[The code of the widget where is published the page to find. Only when pageCode is empty]]></description>
+			<name>widget</name>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>


### PR DESCRIPTION
Hi!

I've added a page resolution by widget in PageInfoTag.
The attribute "pageCode" is no longer required, and the new attribute "widget" will work only when "pageCode" is empty.

Hope helps!
Stefano
