### PR TITLE
fix URLTag's excludeParameters attribute

### DIFF
--- a/src/main/java/com/agiletec/aps/tags/URLTag.java
+++ b/src/main/java/com/agiletec/aps/tags/URLTag.java
@@ -1,30 +1,30 @@
 /*
-*
-* Copyright 2013 Entando S.r.l. (http://www.entando.com) All rights reserved.
-*
-* This file is part of Entando software.
-* Entando is a free software;
-* You can redistribute it and/or modify it
-* under the terms of the GNU General Public License (GPL) as published by the Free Software Foundation; version 2.
-* 
-* See the file License for the specific language governing permissions   
-* and limitations under the License
-* 
-* 
-* 
-* Copyright 2013 Entando S.r.l. (http://www.entando.com) All rights reserved.
-*
-*/
+ *
+ * Copyright 2013 Entando S.r.l. (http://www.entando.com) All rights reserved.
+ *
+ * This file is part of Entando software.
+ * Entando is a free software;
+ * You can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the Free Software Foundation; version 2.
+ * 
+ * See the file License for the specific language governing permissions   
+ * and limitations under the License
+ * 
+ * 
+ * 
+ * Copyright 2013 Entando S.r.l. (http://www.entando.com) All rights reserved.
+ *
+ */
 package com.agiletec.aps.tags;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.TagSupport;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ import com.agiletec.aps.util.ApsWebApplicationUtils;
 public class URLTag extends TagSupport implements IParameterParentTag {
 
 	private static final Logger _logger = LoggerFactory.getLogger(URLTag.class);
-	
+
 	/**
 	 * Prepares a PageURL object; this object may comprehend several sub-tags
 	 */
@@ -54,7 +54,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 		RequestContext reqCtx = (RequestContext) request.getAttribute(RequestContext.REQCTX);
 		try {
 			IURLManager urlManager = 
-				(IURLManager) ApsWebApplicationUtils.getBean(SystemConstants.URL_MANAGER, this.pageContext);
+					(IURLManager) ApsWebApplicationUtils.getBean(SystemConstants.URL_MANAGER, this.pageContext);
 			this._pageUrl = urlManager.createURL(reqCtx);
 			if (_pageCode != null) {
 				_pageUrl.setPageCode(_pageCode);
@@ -68,12 +68,11 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 			}
 		} catch (Throwable t) {
 			_logger.error("Error during tag initialization", t);
-			//ApsSystemUtils.logThrowable(t, this, "doStartTag");
 			throw new JspException("Error during tag initialization", t);
 		}
 		return EVAL_BODY_INCLUDE;
 	}
-	
+
 	/**
 	 * Completes the URL generation making it available for immediate
 	 * output or placing it in a variable
@@ -88,28 +87,27 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 				this.pageContext.getOut().print(url);
 			} catch (Throwable t) {
 				_logger.error("Error closing tag", t);
-				//ApsSystemUtils.logThrowable(t, this, "doEndTag");
 				throw new JspException("Error closing tag", t);
 			}
 		}
 		return EVAL_PAGE;
 	}
-	
+
 	@Override
 	public void addParameter(String name, String value) {
 		this._pageUrl.addParam(name, value);
 	}
-	
+
 	protected List<String> getParametersToExclude() {
 		List<String> parameters = new ArrayList<String>();
 		String csv = this.getExcludeParameters();
 		if (null != csv && csv.trim().length() > 0) {
-			parameters = Arrays.asList(csv.split(","));
+			CollectionUtils.addAll(parameters, csv.split(","));
 		}
 		parameters.add(SystemConstants.LOGIN_PASSWORD_PARAM_NAME);
 		return parameters;
 	}
-	
+
 	@Override
 	public void release() {
 		this._langCode = null;
@@ -117,8 +115,9 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 		this._varName = null;
 		this._paramRepeat = false;
 		this._pageUrl = null;
+		this._excludeParameters = null;
 	}
-	
+
 	/**
 	 * Return the language code
 	 * @return The literal code
@@ -134,7 +133,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public void setLang(String lang) {
 		this._langCode = lang;
 	}
-	
+
 	/**
 	 * Return the page code
 	 * @return The page code
@@ -142,7 +141,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public String getPage() {
 		return _pageCode;
 	}
-	
+
 	/**
 	 * Set the page code
 	 * @param page The page code
@@ -150,7 +149,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public void setPage(String page) {
 		this._pageCode = page;
 	}
-	
+
 	/**
 	 * Return the name of the variable containing the generated URL.
 	 * @return The name of the variable
@@ -158,7 +157,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public String getVar() {
 		return _varName;
 	}
-	
+
 	/**
 	 * Set the name of the variable containing the generated URL.
 	 * @param var The name of the variable
@@ -166,7 +165,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public void setVar(String var) {
 		this._varName = var;
 	}
-	
+
 	/**
 	 * Repeats the parameters of the previous request when true, false otherwise.
 	 * @return Returns the parRepeat.
@@ -174,7 +173,7 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public boolean isParamRepeat() {
 		return _paramRepeat;
 	}
-	
+
 	/**
 	 * Toggles the repetition of the previous query string parameters
 	 * @param paramRepeat True enables the repetition, false otherwise.
@@ -182,30 +181,30 @@ public class URLTag extends TagSupport implements IParameterParentTag {
 	public void setParamRepeat(boolean paramRepeat) {
 		this._paramRepeat = paramRepeat;
 	}
-	
+
 	/**
-     * Gets list of parameter names (comma separated) to exclude from repeating.
+	 * Gets list of parameter names (comma separated) to exclude from repeating.
 	 * By default, this attribute excludes only the password parameter of the login form.
-     * @return the exclude list.
-     */
+	 * @return the exclude list.
+	 */
 	public String getExcludeParameters() {
 		return _excludeParameters;
 	}
-	
+
 	/**
-     * Sets the list of parameter names (comma separated) to exclude from repeating.
+	 * Sets the list of parameter names (comma separated) to exclude from repeating.
 	 * By default, this attribute excludes only the password parameter of the login form.
-     * @param excludeParameters the excludes list (comma separated).
-     */
+	 * @param excludeParameters the excludes list (comma separated).
+	 */
 	public void setExcludeParameters(String excludeParameters) {
 		this._excludeParameters = excludeParameters;
 	}
-	
+
 	private String _langCode;
 	private String _pageCode;
 	private String _varName;
 	private boolean _paramRepeat;
 	private PageURL _pageUrl;
 	private String _excludeParameters;
-	
+
 }


### PR DESCRIPTION
fixes  `URLTag` when using  the `excludeParameters` attribute.
